### PR TITLE
Add control node for S model grippers.

### DIFF
--- a/robotiq_s_model_control/CMakeLists.txt
+++ b/robotiq_s_model_control/CMakeLists.txt
@@ -1,7 +1,7 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_s_model_control)
-find_package(catkin REQUIRED rospy message_generation)
+find_package(catkin REQUIRED rospy message_generation roscpp robotiq_ethercat)
 
 #set the default path for built executables to the "bin" directory
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
@@ -30,9 +30,26 @@ generate_messages()
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    CATKIN_DEPENDS rospy message_runtime
+    CATKIN_DEPENDS rospy message_runtime roscpp robotiq_ethercat
 )
 
+include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${robotiq_ethercat_INCLUDE_DIRS}
+)
+
+add_executable(s_model_ethercat_node
+  src/robotiq_s_model_control/s_model_ethercat_node.cpp
+  src/robotiq_s_model_control/s_model_ethercat_client.cpp
+)
+
+target_link_libraries(s_model_ethercat_node
+   ${robotiq_ethercat_LIBRARIES}
+   ${catkin_LIBRARIES}
+)
+
+add_dependencies(c_model_ethercat_node robotiq_c_model_control_generate_messages_cpp)
 #############
 ## Install ##
 #############

--- a/robotiq_s_model_control/CMakeLists.txt
+++ b/robotiq_s_model_control/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(s_model_ethercat_node
    ${catkin_LIBRARIES}
 )
 
-add_dependencies(c_model_ethercat_node robotiq_c_model_control_generate_messages_cpp)
+add_dependencies(s_model_ethercat_node robotiq_s_model_control_generate_messages_cpp)
 #############
 ## Install ##
 #############

--- a/robotiq_s_model_control/include/robotiq_s_model_control/s_model_ethercat_client.h
+++ b/robotiq_s_model_control/include/robotiq_s_model_control/s_model_ethercat_client.h
@@ -1,0 +1,66 @@
+#ifndef S_MODEL_ETHERCAT_CLIENT_H
+#define S_MODEL_ETHERCAT_CLIENT_H
+
+#include <robotiq_s_model_control/SModel_robot_output.h>
+#include <robotiq_s_model_control/SModel_robot_input.h>
+
+// Forward declaration of EtherCatManager
+namespace robotiq_ethercat
+{
+  class EtherCatManager;
+}
+
+namespace robotiq_s_model_control
+{
+
+/**
+ * \brief This class provides a client for the EtherCAT manager object that
+ *        can translate robot input/output messages and translate them to
+ *        the underlying IO Map.
+ */
+
+class SModelEtherCatClient
+{
+public:
+  typedef robotiq_s_model_control::SModel_robot_output GripperOutput;
+  typedef robotiq_s_model_control::SModel_robot_input GripperInput;
+
+  /**
+   * \brief Constructs a control interface to a S Model Robotiq gripper on
+   *        the given ethercat network and the given slave_no.
+   *
+   * @param[in] manager The interface to an EtherCAT network that the gripper
+   *                    is connected to.
+   *
+   * @param[in] slave_no The slave number of the gripper on the EtherCAT network
+   *                     (>= 1)
+   */
+  SModelEtherCatClient(robotiq_ethercat::EtherCatManager& manager, int slave_no);
+
+  /**
+   * \brief Write the given set of control flags to the memory of the gripper
+   *
+   * @param[in] output The set of output-register values to write to the gripper
+   */
+  void writeOutputs(const GripperOutput& output);
+
+  /**
+   * \brief Reads set of input-register values from the gripper.
+   * \return The gripper input registers as read from the controller IOMap
+   */
+  GripperInput readInputs() const;
+
+  /**
+   * \brief Reads set of output-register values from the gripper.
+   * \return The gripper output registers as read from the controller IOMap
+   */
+  GripperOutput readOutputs() const;
+
+private:
+  robotiq_ethercat::EtherCatManager& manager_;
+  const int slave_no_;
+};
+
+}
+
+#endif

--- a/robotiq_s_model_control/launch/s_model_ethercat.launch
+++ b/robotiq_s_model_control/launch/s_model_ethercat.launch
@@ -1,0 +1,15 @@
+<launch>
+  <arg name="gripper_name" default="gripper" />
+  <arg name="slave_number" default="1" />
+  <arg name="activate" default="True" />
+  <arg name="ifname" default="enp0s20u1" />
+
+  <node pkg="robotiq_s_model_control" type="s_model_ethercat_node" name="gripper_server" output="screen">
+      <param name="ifname" type="str" value="$(arg ifname)" />
+      <param name="activate" type="bool" value="$(arg activate)" />
+      <param name="slave_number" type="int" value="$(arg slave_number)"/>
+
+      <remap from="output" to="/$(arg gripper_name)/output" />
+      <remap from="input" to="/$(arg gripper_name)/input" />
+    </node>
+</launch>

--- a/robotiq_s_model_control/package.xml
+++ b/robotiq_s_model_control/package.xml
@@ -10,8 +10,12 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>robotiq_ethercat</build_depend>
   <run_depend>rospy</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>robotiq_ethercat</run_depend>
 
   <export>
 

--- a/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_client.cpp
+++ b/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_client.cpp
@@ -76,8 +76,8 @@ SModelEtherCatClient::GripperInput SModelEtherCatClient::readInputs() const
   // Object Status
   input.gDTA = map[1] & 0x3;
   input.gDTB = (map[1] >> 0x2) & 0x3;
-  input.gDTB = (map[1] >> 0x4) & 0x3;
-  input.gDTB = (map[1] >> 0x6) & 0x3;
+  input.gDTC = (map[1] >> 0x4) & 0x3;
+  input.gDTS = (map[1] >> 0x6) & 0x3;
 
   // Fault Status
   input.gFLT = map[2] & 0xF;

--- a/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_client.cpp
+++ b/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_client.cpp
@@ -1,0 +1,147 @@
+#include "robotiq_s_model_control/s_model_ethercat_client.h"
+
+#include "robotiq_ethercat/ethercat_manager.h"
+
+// See Robotiq's documentation for the register mapping
+
+// An effort to keep the lines less than 100 char long
+namespace robotiq_s_model_control
+{
+SModelEtherCatClient::SModelEtherCatClient(robotiq_ethercat::EtherCatManager& manager, 
+                                                    int slave_no)
+  : manager_(manager)
+  , slave_no_(slave_no)
+{}
+
+/*
+  See support.robotiq.com -> manual for the register output meanings
+*/
+void SModelEtherCatClient::writeOutputs(const GripperOutput& output)
+{
+  uint8_t map[15] = {0}; // array containing all 15 output registers
+
+  // Pack the Action Request register byte
+  map[0] = (output.rACT & 0x1) | (output.rMOD << 0x1) & 0x6 | ((output.rGTO << 0x3) & 0x8) | ((output.rATR << 0x4) & 0x10);
+
+  // Pack the Gripper Options register byte
+  map[1] =  ((output.rICF << 0x2) & 0x4) | ((output.rICS << 0x3) & 0x8);
+
+  // map[2] is empty
+
+  // Requested Position, Speed and Force (Finger A).
+  map[3]  = output.rPRA;
+  map[4]  = output.rSPA;
+  map[5]  = output.rFRA;
+
+  // Finger B
+  map[6]  = output.rPRB;
+  map[7]  = output.rSPB;
+  map[8]  = output.rFRB;
+
+  // Finger C
+  map[9]  = output.rPRC;
+  map[10] = output.rSPC;
+  map[11] = output.rFRC;
+
+  // Scissor Mode
+  map[12] = output.rPRS;
+  map[13] = output.rSPS;
+  map[14] = output.rFRS;
+
+  for (unsigned i = 0; i < 15; ++i)
+  {
+    manager_.write(slave_no_, i, map[i]);
+  }
+}
+
+SModelEtherCatClient::GripperInput SModelEtherCatClient::readInputs() const
+{
+  uint8_t map[15];
+
+  for (unsigned i = 0; i < 15; ++i)
+  {
+    map[i] = manager_.readInput(slave_no_, i);
+  }
+
+  // Decode Input Registers
+  GripperInput input;
+
+  // Gripper Status
+  input.gACT = map[0] & 0x1;
+  input.gMOD = (map[0] >> 0x1) & 0x3;
+  input.gGTO = (map[0] >> 0x3) & 0x1;
+  input.gIMC = (map[0] >> 0x4) & 0x3;
+  input.gSTA = (map[0] >> 0x6) & 0x3;
+
+  // Object Status
+  input.gDTA = map[1] & 0x3;
+  input.gDTB = (map[1] >> 0x2) & 0x3;
+  input.gDTB = (map[1] >> 0x4) & 0x3;
+  input.gDTB = (map[1] >> 0x6) & 0x3;
+
+  // Fault Status
+  input.gFLT = map[2] & 0xF;
+
+  // Requested Position, Speed and Force (Finger A).
+  input.gPRA = map[3];
+  input.gPOA = map[4];
+  input.gCUA = map[5];
+
+  // Finger B
+  input.gPRB = map[6];
+  input.gPOB = map[7];
+  input.gCUB = map[8];
+
+  // Finger C
+  input.gPRC = map[9];
+  input.gPOC = map[10];
+  input.gCUC = map[11];
+
+  // Scissor Mode
+  input.gPRS = map[12];
+  input.gPOS = map[13];
+  input.gCUS = map[14];
+
+  return input;
+}
+
+SModelEtherCatClient::GripperOutput SModelEtherCatClient::readOutputs() const
+{
+  uint8_t map[15];
+  for (unsigned i = 0; i < 15; ++i)
+  {
+    map[i] = manager_.readOutput(slave_no_, i);
+  }
+
+  GripperOutput output;
+  output.rACT = map[0] & 1;
+  output.rMOD = (map[0] >> 0x1) & 0x6;
+  output.rGTO = (map[0] >> 0x3) & 0x1;
+  output.rATR = (map[0] >> 0x4) & 0x1;
+
+  output.rICF = (map[1] >> 0x2) & 0x4;
+  output.rICS = (map[1] >> 0x3) & 0x8;
+
+  // Finger A
+  output.rPRA = map[3];
+  output.rSPA = map[4];
+  output.rFRA = map[5];
+
+  // Finger B
+  output.rPRB = map[6];
+  output.rSPB = map[7];
+  output.rFRB = map[8];
+
+  // Finger C
+  output.rPRC = map[9];
+  output.rSPC = map[10];
+  output.rFRC = map[11];
+
+  // Scissor Mode
+  output.rPRS = map[12];
+  output.rSPS = map[13];
+  output.rFRS = map[14];
+
+  return output;
+}
+} // end of robotiq_s_model_control namespace

--- a/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_node.cpp
+++ b/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_node.cpp
@@ -1,0 +1,81 @@
+#include "ros/ros.h"
+
+#include <boost/bind.hpp>
+#include <boost/ref.hpp>
+
+#include "robotiq_s_model_control/s_model_ethercat_client.h"
+#include <robotiq_s_model_control/SModel_robot_input.h>
+#include "robotiq_ethercat/ethercat_manager.h"
+
+
+/*
+  Note that this code currently works only to control ONE SModel gripper
+  attached to ONE network interface. If you want to add more grippers
+  to the same network, you'll need to edit the source file.
+*/
+
+// Note that you will likely need to run the following on your binary:
+// sudo setcap cap_net_raw+ep <filename>
+
+
+void changeCallback(robotiq_s_model_control::SModelEtherCatClient& client,
+                    const robotiq_s_model_control::SModelEtherCatClient::GripperOutput::ConstPtr& msg)
+{
+  client.writeOutputs(*msg);
+}
+
+
+int main(int argc, char** argv)
+{
+  using robotiq_ethercat::EtherCatManager;
+  using robotiq_s_model_control::SModelEtherCatClient;
+
+  typedef SModelEtherCatClient::GripperOutput GripperOutput;
+  typedef SModelEtherCatClient::GripperInput GripperInput;
+
+  ros::init(argc, argv, "robotiq_s_model_gripper_node");
+  
+  ros::NodeHandle nh ("~");
+
+  // Parameter names
+  std::string ifname;
+  int slave_no;
+  bool activate;  
+
+  nh.param<std::string>("ifname", ifname, "enp9s0");
+  nh.param<int>("slave_number", slave_no, 1);
+  nh.param<bool>("activate", activate, true);
+
+  // Start ethercat manager
+  EtherCatManager manager(ifname);
+  // register client 
+  SModelEtherCatClient client(manager, slave_no);
+
+  // conditionally activate the gripper
+  if (activate)
+  {
+    // Check to see if resetting is required? Or always reset?
+    GripperOutput out;
+    out.rACT = 0x1;
+    client.writeOutputs(out);
+  }
+
+  // Sorry for the indentation, trying to keep it under 100 chars
+  ros::Subscriber sub = 
+        nh.subscribe<GripperOutput>("output", 1,
+                                    boost::bind(changeCallback, boost::ref(client), _1));
+
+  ros::Publisher pub = nh.advertise<GripperInput>("input", 100);
+
+  ros::Rate rate(10); // 10 Hz
+
+  while (ros::ok()) 
+  {
+    SModelEtherCatClient::GripperInput input = client.readInputs();
+    pub.publish(input);
+    ros::spinOnce();
+    rate.sleep();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
I added an S model controller node for the sake of completeness. This node is basically a copy of the existing node for C models, only that the new node reads and writes to registers that are non-existent for C model grippers. Since both nodes almost do the same, the question is whether we want to generalise some code to avoid duplicated code. I thought about creating a virtual class from which the ethernet_clients are derived, but since the return types of the readInput functions are different we can't just do that. Another option to reduce duplicated code is by having one single node, which loads the appropriate ethercat_client according to some parameter specified by the user. Right now the two nodes are the same only that they load either the S model client or the C model client. Please let me know if you think this minor addition is useful and what you think is best to clean up the code a bit.
